### PR TITLE
chore: add link to mark price docs site information

### DIFF
--- a/mainnet/0.74-proposal-templates/README.md
+++ b/mainnet/0.74-proposal-templates/README.md
@@ -51,7 +51,7 @@ With additional flexibility in setting the liquidity fee, two new methods have b
 
 #### Mark price and “composite” internal price for perpetual funding TWAP updates
 
-For information on the new mark price feilds and how they are used please see the [vega docs site](https://docs.vega.xyz/testnet/tutorials/proposals/new-perpetuals-market#mark-price-configuration).
+For information on the new mark price fields and how they are used please see the [vega docs site](https://docs.vega.xyz/testnet/tutorials/proposals/new-perpetuals-market#mark-price-configuration).
 
 ##### Proposed value(s)
 

--- a/mainnet/0.74-proposal-templates/README.md
+++ b/mainnet/0.74-proposal-templates/README.md
@@ -51,6 +51,8 @@ With additional flexibility in setting the liquidity fee, two new methods have b
 
 #### Mark price and “composite” internal price for perpetual funding TWAP updates
 
+For information on the new mark price feilds and how they are used please see the [vega docs site](https://docs.vega.xyz/testnet/tutorials/proposals/new-perpetuals-market#mark-price-configuration).
+
 ##### Proposed value(s)
 
 The proposed value sits in section `markPriceConfiguration`, with `decayWeight` set to `1.0`, `decayPower` set to `1`, `cashAmount` set to `5000000`, and `sourceWeights` set to `["0.0", "0.0", "0.0", "1.0"]` which means `median` is used as the mark price data source. `sourceStalenessTolerance` is set to `["1m", "1m", "1m", "1m"]`, `compositePriceType` is set to `COMPOSITE_PRICE_TYPE_WEIGHTED` which means mark price is weighted price from data source where external data source is set in section `dataSourcesSpec`.


### PR DESCRIPTION
Adds a link to mark price docs site information

- https://docs.vega.xyz/testnet/tutorials/proposals/new-perpetuals-market#mark-price-configuration